### PR TITLE
52: Adding badge to icon to count selected elements

### DIFF
--- a/chrome/lib/scripts/background.js
+++ b/chrome/lib/scripts/background.js
@@ -25,6 +25,8 @@ chrome.runtime.onMessage.addListener(
             });
             Store.SaveSites(request.sites, sendResponse);
         } else if (request.action === Actions.SAVECURRENTTRACKING) {
+            tracker.setBadge(Object.keys(request.currentTracking).length);
+
             sendResponse({
                 currentTracking: Store.SaveCurrentTracking(request.currentTracking)
             });

--- a/chrome/lib/scripts/core.js
+++ b/chrome/lib/scripts/core.js
@@ -19,12 +19,19 @@ class TrackForMe {
 
     reload() {
         this.setIcon('default');
+        this.setBadge();
         this.removePopup();
     }
 
     removePopup() {
         chrome.browserAction.setPopup({
             popup: ''
+        });
+    }
+
+    setBadge(number) {
+        chrome.browserAction.setBadgeText({
+            text: '' + (number || '')
         });
     }
 

--- a/chrome/lib/scripts/foreground.js
+++ b/chrome/lib/scripts/foreground.js
@@ -40,11 +40,15 @@ const handleClick = (element) => {
         elementContent: element.innerHTML
     };
 
+    currentTracking[tracking.elementPath] = tracking;
+    //This will save the tracking inmediately in the localstorage
+    BackStore.SaveCurrentTracking(currentTracking);
+
     chrome.runtime.sendMessage({
         action: Actions.SNAPSHOT
     }, (response) => {
-        tracking.img = response.imgSrc;
-        currentTracking[tracking.elementPath] = tracking;
+        currentTracking[tracking.elementPath].img = response.imgSrc;
+        //This will update the saved tracking with the image url
         BackStore.SaveCurrentTracking(currentTracking);
     });
 }


### PR DESCRIPTION
This fixes #52 

The change of the badge takes some seconds to be visualized due to that the badge is changed in the core.js and it takes some time to reach that code (you can replay this behavior, testing the extension and clicking some elements on any page). Any suggestions?
