### PR TITLE
Feature/84: Persisting tracking status

### DIFF
--- a/chrome/gulpfile.babel.js
+++ b/chrome/gulpfile.babel.js
@@ -3,7 +3,7 @@
 import source from 'vinyl-source-stream';
 import gulp from 'gulp';
 import run from 'run-sequence';
-import rimraf from 'rimraf';
+import del from 'del';
 import babelify from 'babelify';
 import browserify from 'browserify';
 
@@ -43,13 +43,13 @@ const jsBrowserifyer = (fileName) => {
 //build when a file has changed
 gulp.task('watch', cb => {
   gulp.watch([
-    `${paths.src}/**`
+    `${paths.src}/lib/**/**`
   ], ['build']);
 });
 
 //Clean the app destination, to prepare for new files
-gulp.task('clean', cb => {
-  rimraf(paths.dest, cb);
+gulp.task('clean', () => {
+  return del(paths.dest);
 });
 
 gulp.task('img', () => {

--- a/chrome/lib/css/common.css
+++ b/chrome/lib/css/common.css
@@ -109,3 +109,7 @@
   pointer-events: none;
   opacity: 0.5;
 }
+
+.text-center {
+  text-align: center;
+}

--- a/chrome/lib/css/options.css
+++ b/chrome/lib/css/options.css
@@ -8,93 +8,182 @@ p {
   margin: 2px;
 }
 
+table {
+  background-color: transparent;
+}
+
+label {
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  font-weight: 700;
+}
+
 .panel {
-  width: 45%;
-  height: 700px;
+  width: 90%;
+  min-width: 630px;
+  max-width: 715px;
+  height: auto;
   background-color: white;
   border-radius: 25px;
-  margin: 30px auto;
-  overflow-y: auto;
-  overflow-x: hidden;
+  margin: 25px auto;
 }
 
 .panel-heading {
-  max-width: 100%;
-  height: 60px;
   background-color: #5cb85c;
   border-radius: 25px 25px 0px 0px;
   color: white;
-  padding: 10px 0px 5px 15px;
+  padding: 10px;
 }
 
 .panel-body {
-  max-width: 100%;
+  width: auto;
+  height: auto;
+  padding: 10px;
 }
 
-.input-div {
-  margin: 20px 0px 0px 20%;
+.form-inline {
+  margin: auto 25%;
 }
 
-#time {
-  margin-top: 16px
+.form-group {
+  margin-bottom: 15px;
 }
 
-#time-input, #email-input {
-  height: 30px;
-  border-radius: 8px;
-  padding: 2px;
+.form-control {
+  display: block;
+  width: 100%;
+  height: 34px;
+  padding: 6px 12px;
+  font-size: 14px;
+  line-height: 1.42857143;
+  color: #555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
 }
 
-#email-input {
-  width: 68%;
+.form-control:focus {
+  border-color: #66afe9;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, .6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, .6);
 }
 
-#time-input {
-  width: 70%;
+.form-control::-moz-placeholder {
+  color: #999;
+  opacity: 1;
 }
 
-#email-error {
+.form-control:-ms-input-placeholder {
+  color: #999;
+}
+
+.form-control::-webkit-input-placeholder {
+  color: #999;
+}
+
+.form-control::-ms-expand {
+  background-color: transparent;
+  border: 0;
+}
+
+.form-control[type="email"] {
+  width: 93%;
+  height: 25px;
+}
+
+.form-control-error {
   color: red;
 }
 
-.btn-save {
-  width: 70%;
-  margin: 20px 0px 20px 0px;
-}
-
-#tracking-time-warning {
-  background-color: #f2f2f2;
-  font-size: 15px;
-  width: 68%;
-  text-align: justify;
-  padding: 5px;
-  font-weight: normal;
-}
-
-#trackings-table {
-  margin: 5% 15%;
+table {
+  border-spacing: 0;
   border-collapse: collapse;
 }
 
-#trackings-table th, #trackings-table td {
-  border: 1px solid #e0e0e0;
-  border-collapse: collapse;
-  text-align: left;
-  padding: 15px;
-}
-
+td,
 th {
-  font-size: 20px;
-  background-color: #e7e7e7;
+  padding: 0;
 }
 
-#trackings-table .td-without-border {
-  border: 0px;
+.table {
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 20px;
 }
 
-#trackings-table .td-delete-all {
-  border: 0px;
-  text-align: center;
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  padding: 8px;
+  line-height: 1.42857143;
+  vertical-align: top;
+  border-top: 1px solid #ddd;
+}
+
+.table > thead > tr > th {
+  vertical-align: bottom;
+  border-bottom: 2px solid #ddd;
+}
+
+.table > caption + thead > tr:first-child > th,
+.table > colgroup + thead > tr:first-child > th,
+.table > thead:first-child > tr:first-child > th,
+.table > caption + thead > tr:first-child > td,
+.table > colgroup + thead > tr:first-child > td,
+.table > thead:first-child > tr:first-child > td {
+  border-top: 0;
+}
+
+.table > tbody + tbody {
+  border-top: 2px solid #ddd;
+}
+
+.table .table {
+  background-color: #fff;
+}
+
+.table-bordered {
+  border: 1px solid #ddd;
+}
+
+.table-bordered > thead > tr > th,
+.table-bordered > tbody > tr > th,
+.table-bordered > tfoot > tr > th,
+.table-bordered > thead > tr > td,
+.table-bordered > tbody > tr > td,
+.table-bordered > tfoot > tr > td {
+  border: 1px solid #ddd;
+}
+
+.table-bordered > thead > tr > th,
+.table-bordered > thead > tr > td {
+  border-bottom-width: 2px;
+}
+
+input[type="checkbox"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: 0;
+  margin: 25%;
+  line-height: normal;
+}
+
+input[type="checkbox"]:focus {
+  outline: thin dotted;
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
 }
 
 .img-preview {

--- a/chrome/lib/scripts/core/store.js
+++ b/chrome/lib/scripts/core/store.js
@@ -104,15 +104,25 @@ const Store = {
         trackings.forEach(tracking => {
             let configTracking = config.trackings.find(t => t.elementPath === tracking.elementPath);
             if (configTracking) {
-                configTracking.status = tracking.status;
+                configTracking.lastScanStatus = tracking.lastScanStatus;
                 configTracking.lastScanDate = tracking.lastScanDate;
+                // For now I will always notify the server but #91 will add some control about when to update it
+                this.putTrackingStatus(config.email, tracking);
             }
         });
 
-        console.log('trackings updated', trackings);
-
         this._saveUserConfig(config);
-        //TODO: Should we post the updates to the server?
+    },
+
+    putTrackingStatus(userEmail, tracking) {
+        $.ajax({
+            url: `${ServerBaseUrl}/trackings/statusupdate`,
+            type: 'PUT',
+            data: {
+                email: userEmail,
+                tracking: tracking
+            }
+        });
     }
 };
 

--- a/chrome/lib/scripts/options.js
+++ b/chrome/lib/scripts/options.js
@@ -31,28 +31,32 @@ document.getElementById('email-input')
         document.getElementById('email-error').innerHTML = '';
     });
 
-document.getElementById('tracking-tigger')
-    .addEventListener('click', (e) => {
-        BackStore.RunTracking();
-    });
-
-function displayTrackings(trackings) {
+const displayTrackings = (trackings) => {
     let innerTable = '';
     if (!trackings || !trackings.length) {
-        innerTable = '<tr><td colspan="2">Please add what you need to track. Watch how to do it in this video.</td></tr>';
+        innerTable = '<tr><td colspan="5" class="text-center">' +
+            'Please add what you need to track. Watch how to do it in this video.</td></tr>';
     } else {
-      innerTable = trackings.map(t => trackingRow(t.img, t.url)).join('');
+        innerTable = trackings.map(trackingRow).join('');
     }
     document.getElementById('trackings-tbody').innerHTML = innerTable;
-}
+};
 
-const trackingRow = (imgUrl, url) =>
+const trackingRow = ({ img, url, lastScanStatus, isEnabled }) =>
     `<tr>
     <td>
-      <img class="img-preview" src="${imgUrl}" />
+    <input title="Disable/Enable tracking" checked="${isEnabled}" type="checkbox">
+    </td>
+    <td class="text-center">
+     ${lastScanStatus}
     </td>
     <td>
-      ${url}
+      <a href="${img}" target="_blank">
+      <img class="img-preview" src="${img}" />
+      </a>
+    </td>
+    <td>
+      <a href="${url}" target="_blank">${url}</a>
     </td>
     <td class="td-without-border">
       <button class="btn btn-danger" type="button">X</button>
@@ -68,9 +72,15 @@ const displayTrackingTimeWarning = (trackingTime) => {
 };
 
 const initOptions = () => {
-  BackStore.LoadUserSettings((response) => {
-      setupUserSettings(response.config);
-  });
+    BackStore.LoadUserSettings((response) => {
+        setupUserSettings(response.config);
+    });
 };
 
 initOptions();
+
+//Temporal hack to call the runner
+// Call window.Run() from the console
+window.Run = () => {
+  BackStore.RunTracking();
+};

--- a/chrome/lib/views/options.html
+++ b/chrome/lib/views/options.html
@@ -14,15 +14,15 @@
             <span id="title">TrackForMe</span>
         </div>
         <div class="panel-body">
-            <div class="input-div">
-                <div id="email">
-                    <p>Email: </p>
-                    <input type="email" name="email" id="email-input" placeholder="Add Your Email" required><span id="email-error"></span>
-                    <br>
+            <div class="form-inline">
+                <div class="form-group">
+                    <label for="email-input">Email:</label>
+                    <input type="email" class="form-control" name="email" id="email-input" placeholder="Add Your Email" required>
+                    <span id="email-error" class="form-control-error"></span>
                 </div>
-                <div id="time">
-                    <p>Tracking Time:</p>
-                    <select name="time" id="time-input">
+                <div class="form-group">
+                    <label for="time-input">Tracking Time:</label>
+                    <select name="time" id="time-input" class="form-control">
                         <option value="1">1 min</option>
                         <option value="5">5 min</option>
                         <option value="15" selected="selected">15 min</option>
@@ -33,21 +33,25 @@
                         <option value="1440">1 day</option>
                     </select>
                 </div>
-                <button class="btn btn-success btn-save" id="save-user-settings">Save Changes</button> <span id="saved-message"> </span>
+                <button class="btn btn-success" id="save-user-settings">Save Changes</button> <span id="saved-message"> </span>
                 <div id="tracking-time-warning" class="none"></div>
             </div>
             <hr>
-            <button id="tracking-tigger"> Track'em all, Now! </button>
-            <table id="trackings-table">
-                <thead>
-                    <tr>
-                        <th>Preview</th>
-                        <th>Website</th>
-                    </tr>
-                </thead>
-                <tbody id="trackings-tbody">
-                </tbody>
-            </table>
+            <section>
+                <table id="trackings-table" class="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>State</th>
+                            <th>Status</th>
+                            <th>Preview</th>
+                            <th>Website</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="trackings-tbody">
+                    </tbody>
+                </table>
+            </section>
         </div>
     </div>
     <script src="../scripts/options.js"></script>

--- a/chrome/package.json
+++ b/chrome/package.json
@@ -35,9 +35,9 @@
         "gulp-babel": "^6.1.2",
         "gulp-bower": "0.0.13",
         "gulp-shell": "^0.5.2",
-        "rimraf": "^2.5.2",
         "run-sequence": "^1.1.5",
-        "vinyl-source-stream": "^1.1.0"
+        "vinyl-source-stream": "^1.1.0",
+        "del": "^2.2.0"
     },
     "dependencies": {
         "amplify-store": "0.0.5",

--- a/common/src/baseTracker.js
+++ b/common/src/baseTracker.js
@@ -23,24 +23,13 @@ class BaseTracker {
 
         const currentElement = this.getElementByPath(path);
 
-        if (!currentElement) {
-            return {
-                changed: true,
-                reason: status.UNEXISTING
-            };
-        }
+        if (!currentElement)
+            return status.UNEXISTING;
 
-        if (lastContent !== currentElement.innerHTML) {
-            return {
-                changed: true,
-                reason: status.CHANGED
-            };
-        }
+        if (lastContent !== currentElement.innerHTML)
+            return status.CHANGED;
 
-        return {
-            changed: false,
-            reason: status.NOCHANGED
-        };
+        return status.NOCHANGES;
     }
 }
 

--- a/common/src/models/tracking.js
+++ b/common/src/models/tracking.js
@@ -1,4 +1,6 @@
 'use strict';
+
+import status from '../trackingStatus';
 const COLLECTION = 'Trackings';
 
 export default (mongoose) => {
@@ -21,6 +23,10 @@ export default (mongoose) => {
                 lastScanDate: {
                     type: Date,
                     default: Date.now
+                },
+                lastScanStatus: {
+                    type: String,
+                    default: status.UNTRACKED
                 },
                 checkFrequency: {
                     type: Number,

--- a/common/src/trackingActivity.js
+++ b/common/src/trackingActivity.js
@@ -55,7 +55,7 @@ class TrackingActivity {
                     let trackings = this.getTrackingsNotEvaluated(tracking.url);
 
                     trackings.forEach(t => {
-                        t.status = tracker.checkElementStatus(t.elementContent, t.elementPath);
+                        t.lastScanStatus = tracker.checkElementStatus(t.elementContent, t.elementPath);
                         t.evaluated = true;
                         t.lastScanDate = new Date();
                     });

--- a/common/src/trackingStatus.js
+++ b/common/src/trackingStatus.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const TrackingStatus = {
-  UNEXISTING: `The element doesn't exist`,
-  CHANGED: 'Element content has changed',
-  NOCHANGED: `Element didn't change`
+  UNEXISTING: 'Unexisting',
+  CHANGED: 'Changed',
+  NOCHANGES: 'No Changes',
+  UNTRACKED: 'Untracked'
 };
 
 export default TrackingStatus;

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,6 @@
     "gulp-copy": "0.0.2",
     "gulp-live-server": "0.0.29",
     "gulp-shell": "^0.5.2",
-    "rimraf": "^2.5.2",
     "run-sequence": "^1.1.5",
     "vinyl-source-stream": "^1.1.0"
   },

--- a/web/src/routes/trackings.js
+++ b/web/src/routes/trackings.js
@@ -48,6 +48,7 @@ router.post('/', (req, res) => {
                 });
             }
         });
+        //TODO: Possible bug: I don't think this is happening after saving all trackings on line 44.
         res.send(`Trackings saved`);
     }
 });
@@ -63,6 +64,32 @@ router.post('/image', (req, res) => {
             .catch(err => res.status(500).send('Internal error: ' + err.stack));
     }
 });
+
+router.put('/statusupdate', (req, res) => {
+    var userEmail = req.body.email;
+    var tracking = req.body.tracking;
+    if (!userEmail) {
+        res.status(500).send('User Email Required');
+    } else if (!tracking) {
+        res.status(500).send('Tracking Required');
+    } else {
+        Tracking.findOne({'_id' : tracking._id}, (err, t) => {
+            if (err) {
+                res.status(500).send(err);
+            } else {
+                t.lastScanStatus = tracking.lastScanStatus;
+                t.lastScanDate = tracking.lastScanDate;
+                t.save((trackingErr, saved) => {
+                    if (trackingErr)
+                        res.status(500).send(`Error saving the tracking: ${trackingErr}`);
+                    else
+                        res.status(200).send(saved);
+                });
+            }
+        });
+    }
+});
+
 
 router.get('/run', (req, res) => {
     new ServerTrackingRunner(ServerStore(Tracking))


### PR DESCRIPTION
This fixes #84

I spent some time fixing some responsiveness situations we were having in the options page, this is related to #30. I tried to followed the bootstrap pattern.

I also added the endpoint for updating the tracking status in the server from the chrome which is related to #91 because I need it in other to reflect the changes when the user has an email.

This is how options.html looks like right now:

<img width="955" alt="screen shot 2016-05-02 at 12 14 14 am" src="https://cloud.githubusercontent.com/assets/1899538/14947119/a775e668-0ffb-11e6-8387-3b9b0db2b841.png">
