### PR TITLE
#35: Auth Mongodb

### DIFF
--- a/web/config.json
+++ b/web/config.json
@@ -8,5 +8,7 @@
     }
   },
   "maxScreenshotSize" : "5mb",
-  "NODE_ENV" : "development"
+  "NODE_ENV" : "development",
+  "dbConnectionString" : "mongodb://localhost:27017/trackforme",
+  "PORT" : 8000
 }


### PR DESCRIPTION
I enabled authentication on the server, for an easier management of the db-credentials I extracted the connectionString to the config file. There will be the authenticated connection string in the server.

I didn't see the case of adding auth when we're working locally since this is only for testing and we don't need any security there, we can leave it as is currently.

For #41 We only need to environment right now, the local environment which is the one that everyone has on the local machine, and the prod environment which is the server one.

After we get our first official release, We can create another branch probably called `develop` and create a mirror web from there, just for testing before releasing, but for now, we are pushing directly to master which means that everything approves in the PRs goes to production.

We'll have a different interaction when the chrome extension official publishing come into play since we'll need to match the server version with the official chrome extension out.
